### PR TITLE
sync dependencies to the 0.2.0

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,5 +1,5 @@
 {
   "bs-platform": "^3.1.5",
   "reason-react": "^0.4.2",
-  "rebolt": "^0.1.0"
+  "rebolt": "^0.2.0"
 }


### PR DESCRIPTION
Currently this generator is installed `rebolt-navigation v 0.1.0`, so this will sync with the v 0.2.0

#1 